### PR TITLE
Make properties for preview configurable

### DIFF
--- a/src/Limbo.Umbraco.Seo/App_Plugins/Limbo.Umbraco.Seo/Scripts/Controllers/Preview.js
+++ b/src/Limbo.Umbraco.Seo/App_Plugins/Limbo.Umbraco.Seo/Scripts/Controllers/Preview.js
@@ -23,7 +23,7 @@
     let seoMetaDescriptionTab = -1;
     let seoMetaDescriptionProperty = -1;
 
-    console.log($scope.editorState.current);
+    let serverVariables = Umbraco.Sys.ServerVariables.LimboUmbracoSEO;
 
     const variant = $scope.editorState.current.variants[0];
     variant.tabs.forEach(function (tab, tabIndex) {
@@ -31,20 +31,19 @@
         tab.properties.forEach(function (property, propertyIndex) {
 
             switch (property.alias) {
-                case "title":
-                case "pageTitle":
+                case serverVariables.titlePropertyAlias:
                     titleTab = tabIndex;
                     titleProperty = propertyIndex;
                     break;
-                case "seoTitle":
+                case serverVariables.seoTitlePropertyAlias:
                     seoTitleTab = tabIndex;
                     seoTitleProperty = propertyIndex;
                     break;
-                case "teaser":
+                case serverVariables.teaserPropertyAlias:
                     teaserTab = tabIndex;
                     teaserProperty = propertyIndex;
                     break;
-                case "seoMetaDescription":
+                case serverVariables.seoMetaDescriptionPropertyAlias:
                     seoMetaDescriptionTab = tabIndex;
                     seoMetaDescriptionProperty = propertyIndex;
                     break;

--- a/src/Limbo.Umbraco.Seo/Composers/SeoComposer.cs
+++ b/src/Limbo.Umbraco.Seo/Composers/SeoComposer.cs
@@ -1,6 +1,10 @@
-﻿using Limbo.Umbraco.Seo.Sitemaps;
+﻿using Limbo.Umbraco.Seo.Notifications;
+using Limbo.Umbraco.Seo.Options;
+using Limbo.Umbraco.Seo.Sitemaps;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
 
 namespace Limbo.Umbraco.Seo.Composers {
@@ -9,6 +13,8 @@ namespace Limbo.Umbraco.Seo.Composers {
 
         public void Compose(IUmbracoBuilder builder) {
             builder.Services.AddUnique<ISitemapHelper, SitemapHelper>();
+            builder.Services.Configure<SEOPropertyAliasOptions>(builder.Config.GetSection(SEOPropertyAliasOptions.SectionName));
+            builder.AddNotificationHandler<ServerVariablesParsingNotification, ServerVariablesNotificationHandler>();
         }
     }
 

--- a/src/Limbo.Umbraco.Seo/Notifications/ServerVariablesNotificationHandler.cs
+++ b/src/Limbo.Umbraco.Seo/Notifications/ServerVariablesNotificationHandler.cs
@@ -1,0 +1,24 @@
+﻿using Limbo.Umbraco.Seo.Options;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Limbo.Umbraco.Seo.Notifications {
+    public class ServerVariablesNotificationHandler : INotificationHandler<ServerVariablesParsingNotification> 
+    {
+        private readonly IOptions<SEOPropertyAliasOptions> _options;
+
+        public ServerVariablesNotificationHandler(IOptions<SEOPropertyAliasOptions> options) {
+            _options = options;
+        }
+
+        public void Handle(ServerVariablesParsingNotification notification) {
+            notification.ServerVariables.Add("LimboUmbracoSEO", new {
+                titlePropertyAlias = _options.Value.TitlePropertyAlias ?? "title",
+                seoTitlePropertyAlias = _options.Value.SeoTitlePropertyAlias ?? "seoTitle",
+                teaserPropertyAlias = _options.Value.TeaserPropertyAlias ?? "teaser",
+                seoMetaDescriptionPropertyAlias = _options.Value.SeoMetaDescriptionPropertyAlias ?? "seoMetaDescription"
+            });
+        }
+    }
+}

--- a/src/Limbo.Umbraco.Seo/Options/SEOPropertyAliasOptions.cs
+++ b/src/Limbo.Umbraco.Seo/Options/SEOPropertyAliasOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Limbo.Umbraco.Seo.Options {
+    public class SEOPropertyAliasOptions {
+        public const string SectionName = "Limbo.Umbraco.SEO";
+        public string TitlePropertyAlias { get; set; }
+        public string SeoTitlePropertyAlias { get; set; }
+        public string TeaserPropertyAlias { get; set; }
+        public string SeoMetaDescriptionPropertyAlias { get; set; }
+    }
+}


### PR DESCRIPTION
Added options pattern to read property aliases from appsettings.
Added notification handler for server variables to make configured property aliases useable in preview controller.
Changed controller to use configured aliases to search for properties.